### PR TITLE
remove note about transparent sprites improving performance

### DIFF
--- a/about/ayos-special-tips.html
+++ b/about/ayos-special-tips.html
@@ -1,5 +1,4 @@
 <ul>
-<li><p>In some cases (usually smaller games), adding the &#8216;Transparent Sprites&#8217; hack can actually improve the performance of your Bitsy game.</p></li>
 <li><p>Looking for the &#8216;Paragraph Break&#8217; hack? Use &#8216;Long Dialog&#8217; instead. It has all the same functionality and more!</p></li>
 <li><p>If you&#8217;re still using the exit-from-dialog or end-from-dialog hacks, make sure to check out and new the new locked exits functionality in Bitsy 7.0! (These hacks are likely to be deprecated in the future.)</p></li>
 <li><p>You can access the Bitsy game variables from JavaScript using <code>window.scriptInterpreter.GetVariable(variableName)</code> and <code>window.scriptInterpreter.SetVariable(variableName)</code></p></li>

--- a/about/ayos-special-tips.md
+++ b/about/ayos-special-tips.md
@@ -1,5 +1,3 @@
-* In some cases (usually smaller games), adding the 'Transparent Sprites' hack can actually improve the performance of your Bitsy game.
-
 * Looking for the 'Paragraph Break' hack? Use 'Long Dialog' instead. It has all the same functionality and more!
 
 * If you're still using the exit-from-dialog or end-from-dialog hacks, make sure to check out and new the new locked exits functionality in Bitsy 7.0! (These hacks are likely to be deprecated in the future.)


### PR DESCRIPTION
this isn't true anymore; this was originally the case due to transparent sprites completely drawing images to the canvas using a different method than bitsy, but bitsy has since been refactored to use the same method